### PR TITLE
Fix: Do not emit error logs when sending daily recap if no error

### DIFF
--- a/internal/notification/mail_recap.go
+++ b/internal/notification/mail_recap.go
@@ -135,6 +135,7 @@ func SendMailRecap(tx *gorm.DB, from, to time.Time) error {
 			Recipient: configuration.DailyRecapRecipient(),
 			Content:   recapOut.String(),
 		})
+		return nil
 	}
 
 	logrus.WithError(err).WithField("recipient", configuration.DailyRecapRecipient()).Error("cannot send daily recap")


### PR DESCRIPTION
Do not print an error logs when processing the daily mailbox and sending daily recap if no error is encountered.

This was due to a missing return in the 'valid state'.